### PR TITLE
ツイートボタンを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,33 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 
+<head>
+<title>機械卒論タイマー</title>
+<script src="./sotsuron_timer.js"></script>
+</head>
+
+<body>
 <div class="container">
-<center><font size="10">卒業論文提出締め切りまで</font><center><br>
+<font size="10">卒業論文提出締め切りまで</font><br>
 <div id="countOutput" style="color:blue;  font-size:100px; text-align:center;"></div>
 
 <button id="ryuunen_button" onclick="ryuunen()">時間を増やす</button>
+
+<div id="twitter_container">
+    <a class="twitter-share-button"
+    id="tweet_button"
+    href="https://twitter.com/intent/tweet"
+    data-hashtags="機械卒論タイマー"
+    data-size="large">
+    Tweet</a>
+</div>
+<script>
+window.twttr = (function (d,s,id) {
+    var t, js, fjs = d.getElementsByTagName(s)[0];
+    if (d.getElementById(id)) return; js=d.createElement(s); js.id=id;
+    js.src="http://platform.twitter.com/widgets.js"; fjs.parentNode.insertBefore(js, fjs);
+    return window.twttr || (t = { _e: [], ready: function(f){ t._e.push(f) } });
+}(document, "script", "twitter-wjs"));
+</script>
 </div>
 
 <style>
@@ -21,35 +44,4 @@ button#ryuunen_button{
   overflow: hidden;
 }
 </style>
-
-<script>
-let graduateYear = 2019;
-let anyDate = new Date(`${graduateYear}/2/1 12:00:00`);
-
-function dateCounter() {
-    var timer = setInterval(function() {
-    var nowDate = new Date();
-    var daysBetween = Math.ceil((anyDate - nowDate)/(1000*60*60*24)) - 1;
-    var ms = (anyDate - nowDate);
-    if (ms >= 0) {
-        var h = Math.floor(ms / 3600000);
-        var _h = h % 24;
-        var m = Math.floor((ms - h * 3600000) / 60000);
-        var s = Math.round((ms - h * 3600000 - m * 60000) / 1000);
-        var element = document.getElementById("countOutput") ;
-        element.textContent = "残り" +daysBetween + "日と" +_h + "時間" + m + "分" +s + "秒";
-
-        if ((h == 0) && (m == 0) && (s == 0)) {
-        alert("時間です！");
-        clearInterval(timer);
-        }
-    }else{
-    }
-    }, 1000);
-}
-
-const ryuunen = () => {
-  anyDate = new Date(`${++graduateYear}/2/1 12:00:00`);
-}
-dateCounter();
-</script>
+</body>

--- a/sotsuron_timer.js
+++ b/sotsuron_timer.js
@@ -1,0 +1,49 @@
+const initialGraduateYear = 2019;
+let graduateYear = initialGraduateYear;
+let anyDate = new Date(`${graduateYear}/2/1 12:00:00`);
+let tweetText = "";
+let forceRefresh = false;
+
+const refreshTweetText = text => {
+    const twitterContainer = document.getElementById("twitter_container");
+    twitterContainer.innerHTML = '<a class="twitter-share-button" id="tweet_button" href="https://twitter.com/intent/tweet" data-hashtags="機械卒論タイマー" data-size="large">';
+    twitterContainer.getElementsByTagName("a")[0].setAttribute("data-text", text);
+    twttr.widgets.load();
+};
+
+function dateCounter() {
+    var timer = setInterval(function() {
+    var nowDate = new Date();
+    var daysBetween = Math.ceil((anyDate - nowDate)/(1000*60*60*24)) - 1;
+    var ms = (anyDate - nowDate);
+    forceRefresh = forceRefresh || tweetText === "";
+
+    if (ms >= 0) {
+        var h = Math.floor(ms / 3600000);
+        var _h = h % 24;
+        var m = Math.floor((ms - h * 3600000) / 60000);
+        var s = Math.round((ms - h * 3600000 - m * 60000) / 1000);
+        var element = document.getElementById("countOutput") ;
+        element.textContent = "残り" +daysBetween + "日と" +_h + "時間" + m + "分" +s + "秒";
+
+        tweetText = `卒業論文提出締め切りまで残り${daysBetween}日${_h}時間${m}分`;
+        if(graduateYear - initialGraduateYear > 0)
+            tweetText += `（${graduateYear - initialGraduateYear}回時間を増やしました！）`;
+
+        if ((h == 0) && (m == 0) && (s == 0)) {
+        alert("時間です！");
+        clearInterval(timer);
+        }
+    }else{
+        tweetText = "卒業論文提出締め切りを過ぎました";
+    }
+    if(forceRefresh || ms % 60000 <= 1000) refreshTweetText(tweetText); // every 1 minute
+    forceRefresh = false;
+    }, 1000);
+}
+
+const ryuunen = () => {
+    anyDate = new Date(`${++graduateYear}/2/1 12:00:00`);
+    forceRefresh = true;
+}
+dateCounter();

--- a/sotsuron_timer.js
+++ b/sotsuron_timer.js
@@ -16,6 +16,7 @@ function dateCounter() {
     var nowDate = new Date();
     var daysBetween = Math.ceil((anyDate - nowDate)/(1000*60*60*24)) - 1;
     var ms = (anyDate - nowDate);
+    var element = document.getElementById("countOutput");
     forceRefresh = forceRefresh || tweetText === "";
 
     if (ms >= 0) {
@@ -23,21 +24,18 @@ function dateCounter() {
         var _h = h % 24;
         var m = Math.floor((ms - h * 3600000) / 60000);
         var s = Math.round((ms - h * 3600000 - m * 60000) / 1000);
-        var element = document.getElementById("countOutput") ;
         element.textContent = "残り" +daysBetween + "日と" +_h + "時間" + m + "分" +s + "秒";
 
         tweetText = `卒業論文提出締め切りまで残り${daysBetween}日${_h}時間${m}分`;
         if(graduateYear - initialGraduateYear > 0)
             tweetText += `（${graduateYear - initialGraduateYear}回時間を増やしました！）`;
-
-        if ((h == 0) && (m == 0) && (s == 0)) {
+    }else{
         alert("時間です！");
         clearInterval(timer);
-        }
-    }else{
+        element.textContent = "残り0日と0時間0分0秒";
         tweetText = "卒業論文提出締め切りを過ぎました";
     }
-    if(forceRefresh || ms % 60000 <= 1000) refreshTweetText(tweetText); // every 1 minute
+    if(forceRefresh || Math.abs(ms % 60000) <= 1000) refreshTweetText(tweetText); // every 1 minute
     forceRefresh = false;
     }, 1000);
 }


### PR DESCRIPTION
## 機能
ツイートボタンを追加します。ボタンを押すと、
> 卒業論文提出締め切りまで残りdd日hh時間mm分 #機械卒論タイマー

の形でツイートします。

<img width="400" alt="0031-01-24 20 05 24" src="https://user-images.githubusercontent.com/16277200/51675474-1d55a700-2017-11e9-8ee2-5222f863f5ce.png">

また、「時間を増やす」を利用している場合はその旨もツイートに含まれます。
<img width="400" alt="0031-01-24 20 07 30" src="https://user-images.githubusercontent.com/16277200/51675495-2ba3c300-2017-11e9-9600-4787d8971a2e.png">

## 実装
- Twitter公式のツイート用ウィジェットを使用しています
- このウィジェットでツイート内容を書き換えるにはボタンごと再生成しなければならないため、毎秒書き換えるとボタンが頻繁に点滅してしまいます
    - 回避策として書き換えを1分おきに抑えました
    - ただし、ページを開いた直後と「時間を増やす」ボタンを押した直後は、強制で書き換えます
- JS部分が長くなってきたため別ファイルに分離しました
